### PR TITLE
Feature/test create project [OSF-8791]

### DIFF
--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -33,7 +33,7 @@ class DashboardPage(OSFBasePage):
                     logo = self.find_element(By.NAME, institution)
                     return not logo.value_of_css_property('filter') == 'grayscale(100%)'
             except:
-                return False
+                raise ValueError('Institution logo for {} not present in modal'.format(institution))
 
 
     class ProjectCreatedModal(BaseElement):

--- a/pages/project.py
+++ b/pages/project.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 
 class ProjectPage(OSFBasePage):
 
-    locator_dictionary = {
+    locators = {
         'project_title':(By.ID, 'nodeTitleEditable'),
     }
 

--- a/pages/project.py
+++ b/pages/project.py
@@ -1,0 +1,15 @@
+import settings
+import urllib.parse
+from pages.base import OSFBasePage
+from selenium.webdriver.common.by import By
+
+
+class ProjectPage(OSFBasePage):
+
+    locator_dictionary = {
+        'project_title':(By.ID, 'nodeTitleEditable'),
+    }
+
+    def __init__(self, driver, guid=''):
+        super(self.__class__, self).__init__(driver)
+        self.url = urllib.parse.urljoin(settings.OSF_HOME, guid)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -28,7 +28,7 @@ class TestDashboardPage:
         assert project_page.project_title.text == project_title, "Project title incorrect."
 
     def test_modal_buttons(self):
-        institutions = ['Center For Open Science [Stage]'] #TODO: Get user institutions dynamically
+        #TODO: Get user institutions from user object
         self.dashboard_page.create_project_button.click()
 
         create_project_modal = self.dashboard_page.CreateProjectModal(self.driver)
@@ -42,10 +42,11 @@ class TestDashboardPage:
         with pytest.raises(ValueError):
             create_project_modal.template_dropdown
 
-        create_project_modal.remove_all_link.click()
-        assert not create_project_modal.institutions_are_selected(institutions)
-        create_project_modal.select_all_link.click()
-        assert create_project_modal.institutions_are_selected(institutions)
+        #TODO: Add back when institutions can be grabbed from user
+        # create_project_modal.remove_all_link.click()
+        # assert not create_project_modal.institutions_are_selected(institutions)
+        # create_project_modal.select_all_link.click()
+        # assert create_project_modal.institutions_are_selected(institutions)
 
         create_project_modal.cancel_button.click()
         with pytest.raises(ValueError):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,18 +1,17 @@
-import unittest
 import pytest
 
 from utils import launch_driver, login
 from pages.project import ProjectPage
 from pages.dashboard import DashboardPage
 
-#TODO: Change to pytest?
-class DashboardPageTests(unittest.TestCase):
+
+class TestDashboardPage:
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.driver = launch_driver()
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dashboard_page = DashboardPage(self.driver)
         self.dashboard_page.goto()
         login(self.dashboard_page)
@@ -52,10 +51,7 @@ class DashboardPageTests(unittest.TestCase):
         with pytest.raises(ValueError):
             create_project_modal.modal
 
-
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.driver.quit()
 
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -28,7 +28,7 @@ class TestDashboardPage:
         assert project_page.project_title.text == project_title, "Project title incorrect."
 
     def test_modal_buttons(self):
-        institutions = ['Center For Open Science [Test]'] #TODO: Get user institutions dynamically
+        institutions = ['Center For Open Science [Stage]'] #TODO: Get user institutions dynamically
         self.dashboard_page.create_project_button.click()
 
         create_project_modal = self.dashboard_page.CreateProjectModal(self.driver)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,8 +1,11 @@
 import unittest
+import pytest
 
 from utils import launch_driver, login
+from pages.project import ProjectPage
 from pages.dashboard import DashboardPage
 
+#TODO: Change to pytest?
 class DashboardPageTests(unittest.TestCase):
 
     @classmethod
@@ -22,6 +25,32 @@ class DashboardPageTests(unittest.TestCase):
         create_project_modal.create_project_button.click()
         project_created_modal = self.dashboard_page.ProjectCreatedModal(self.driver)
         project_created_modal.go_to_project_button.click()
+        project_page = ProjectPage(self.driver)
+        assert project_page.project_title.text == project_title, "Project title incorrect."
+
+    def test_modal_buttons(self):
+        institutions = ['Center For Open Science [Test]'] #TODO: Get user institutions dynamically
+        self.dashboard_page.create_project_button.click()
+
+        create_project_modal = self.dashboard_page.CreateProjectModal(self.driver)
+
+        create_project_modal.more_arrow.click()
+        assert create_project_modal.description_input, "Description input missing."
+        assert create_project_modal.template_dropdown, "Template dropdown missing."
+        create_project_modal.more_arrow.click()
+        with pytest.raises(ValueError):
+            create_project_modal.description_input
+        with pytest.raises(ValueError):
+            create_project_modal.template_dropdown
+
+        create_project_modal.remove_all_link.click()
+        assert not create_project_modal.institutions_are_selected(institutions)
+        create_project_modal.select_all_link.click()
+        assert create_project_modal.institutions_are_selected(institutions)
+
+        create_project_modal.cancel_button.click()
+        with pytest.raises(ValueError):
+            create_project_modal.modal
 
 
     @classmethod


### PR DESCRIPTION
## Purpose

Create tests for adding a project from the dashboard.

## Changes

Add test for creating a project from dashboard
Add test to check the create project modal
Add beginnings of `ProjectPage`

## Side effects

None

## Ticket

https://openscience.atlassian.net/browse/OSF-8791
