### PR TITLE
Feature/locator class

### DIFF
--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -1,32 +1,29 @@
 import settings
 
-from pages.base import OSFBasePage, BaseElement
 from selenium.webdriver.common.by import By
-
+from pages.base import OSFBasePage, BaseElement, Locator
 
 class DashboardPage(OSFBasePage):
 
-    locators = {
-        'identity': (By.CSS_SELECTOR, '#osfHome > div.prereg-banner', settings.LONG_TIMEOUT),
-        'create_project_button': (By.CSS_SELECTOR, 'button.btn-success:nth-child(1)', settings.LONG_TIMEOUT),
-    }
+    # Locators
+    identity = Locator(By.CSS_SELECTOR, '#osfHome > div.prereg-banner', settings.LONG_TIMEOUT)
+    create_project_button = Locator(By.CSS_SELECTOR, 'button.btn-success:nth-child(1)', settings.LONG_TIMEOUT)
 
     def __init__(self, driver, verify=False):
         super(DashboardPage, self).__init__(driver, verify, require_login=True)
 
     class CreateProjectModal(BaseElement):
 
-        locators = {
-            'modal': (By.ID, 'addProjectFromHome'),
-            'create_project_button': (By.CSS_SELECTOR, '#addProjectFromHome > div > div > div.modal-footer > button.btn.btn-success'),
-            'cancel_button': (By.CSS_SELECTOR, '#addProjectFromHome > div > div > div.modal-footer > button.btn.btn-default'),
-            'title_input': (By.CSS_SELECTOR, '.form-control'),
-            'select_all_link': (By.LINK_TEXT, 'Select all'),
-            'remove_all_link': (By.LINK_TEXT, 'Remove all'),
-            'more_arrow': (By.CSS_SELECTOR, '#addProjectFromHome > div > div > div.modal-body > div > div.text-muted.pointer'),
-            'description_input': (By.CSS_SELECTOR, '#addProjectFromHome > div > div > div.modal-body > div > div:nth-child(4) > input'),
-            'template_dropdown': (By.ID, 'select2-chosen-2'),
-        }
+        # Locators
+        modal = Locator(By.ID, 'addProjectFromHome')
+        create_project_button = Locator(By.CSS_SELECTOR, '#addProjectFromHome > div > div > div.modal-footer > button.btn.btn-success')
+        cancel_button = Locator(By.CSS_SELECTOR, '#addProjectFromHome > div > div > div.modal-footer > button.btn.btn-default')
+        title_input = Locator(By.CSS_SELECTOR, '.form-control')
+        select_all_link = Locator(By.LINK_TEXT, 'Select all')
+        remove_all_link = Locator(By.LINK_TEXT, 'Remove all')
+        more_arrow = Locator(By.CSS_SELECTOR, '#addProjectFromHome > div > div > div.modal-body > div > div.text-muted.pointer')
+        description_input = Locator(By.CSS_SELECTOR, '#addProjectFromHome > div > div > div.modal-body > div > div:nth-child(4) > input')
+        template_dropdown = Locator(By.ID, 'select2-chosen-2')
 
         def institutions_are_selected(self, institutions):
             try:
@@ -38,7 +35,6 @@ class DashboardPage(OSFBasePage):
 
     class ProjectCreatedModal(BaseElement):
 
-        locators = {
-            'go_to_project_button': (By.CSS_SELECTOR, '#addProjectFromHome > div > div > div > div.modal-footer > a', settings.LONG_TIMEOUT),
-            'keep_working_here_button': (By.CSS_SELECTOR, '#addProjectFromHome > div > div > div > div.modal-footer > button'),
-        }
+        # Locators
+        go_to_project_button = Locator(By.CSS_SELECTOR, '#addProjectFromHome > div > div > div > div.modal-footer > a', settings.LONG_TIMEOUT)
+        keep_working_here_button = Locator(By.CSS_SELECTOR, '#addProjectFromHome > div > div > div > div.modal-footer > button')

--- a/pages/landing.py
+++ b/pages/landing.py
@@ -1,12 +1,11 @@
 import settings
 
-from pages.base import OSFBasePage
+from pages.base import OSFBasePage, Locator
 from selenium.webdriver.common.by import By
 
 
 class LandingPage(OSFBasePage):
     url = settings.OSF_HOME
 
-    locators = {
-        'identity': (By.ID, 'home-hero', settings.LONG_TIMEOUT),
-    }
+    # Locators
+    identity = Locator(By.ID, 'home-hero', settings.LONG_TIMEOUT)

--- a/pages/meeting.py
+++ b/pages/meeting.py
@@ -1,17 +1,15 @@
 import settings
 
-from pages.base import OSFBasePage, Navbar
 from selenium.webdriver.common.by import By
-
+from pages.base import OSFBasePage, Navbar, Locator
 
 class MeetingPage(OSFBasePage):
     url = settings.OSF_HOME + '/meetings'
 
-    locators = {
-        'identity': (By.CSS_SELECTOR, 'div.osf-meeting-header-img', settings.LONG_TIMEOUT),
-        'register_button': (By.CSS_SELECTOR, 'div.osf-meeting-header-img div.osf-meeting-header div button[data-target="#osf-meeting-register"]', settings.LONG_TIMEOUT),
-        'upload_button': (By.CSS_SELECTOR, 'div.osf-meeting-header-img div.osf-meeting-header div button[data-target="#osf-meeting-upload"]', settings.LONG_TIMEOUT),
-    }
+    # Locators
+    identity = Locator(By.CSS_SELECTOR, 'div.osf-meeting-header-img', settings.LONG_TIMEOUT)
+    register_button = Locator(By.CSS_SELECTOR, 'div.osf-meeting-header-img div.osf-meeting-header div button[data-target="#osf-meeting-register"]', settings.LONG_TIMEOUT)
+    upload_button = Locator(By.CSS_SELECTOR, 'div.osf-meeting-header-img div.osf-meeting-header div button[data-target="#osf-meeting-upload"]', settings.LONG_TIMEOUT)
 
     def __init__(self, driver, verify=False):
         super(MeetingPage, self).__init__(driver, verify)
@@ -19,12 +17,8 @@ class MeetingPage(OSFBasePage):
 
     class MeetingPageNavbar(Navbar):
 
-        locators = {
-            **Navbar.locators,
-            **{
-                'support_link': (By.LINK_TEXT, 'Support'),
-            }
-        }
+        # Locators
+        support_link = Locator(By.LINK_TEXT, 'Support')
 
         def verify(self):
             return self.current_service.text == 'MEETINGS'

--- a/pages/preprint.py
+++ b/pages/preprint.py
@@ -1,16 +1,15 @@
 import settings
 
-from pages.base import OSFBasePage, Navbar
+from pages.base import OSFBasePage, Navbar, Locator
 from selenium.webdriver.common.by import By
 
 
 class PreprintPage(OSFBasePage):
     url = settings.OSF_HOME + '/preprints'
 
-    locators = {
-        'identity': (By.CSS_SELECTOR, 'body.ember-application > div.ember-view > div.preprints-page > div.preprint-header', settings.LONG_TIMEOUT),
-        'add_preprint_link': (By.CSS_SELECTOR, 'div.preprint-page div.preprint-header div.container div div a[href="/preprints/submit"]', settings.LONG_TIMEOUT),
-    }
+    # Locators
+    identity = Locator(By.CSS_SELECTOR, 'body.ember-application > div.ember-view > div.preprints-page > div.preprint-header', settings.LONG_TIMEOUT)
+    add_preprint_link = Locator(By.CSS_SELECTOR, 'div.preprint-page div.preprint-header div.container div div a[href="/preprints/submit"]', settings.LONG_TIMEOUT)
 
     def __init__(self, driver, verify=False):
         super(PreprintPage, self).__init__(driver, verify)
@@ -18,14 +17,10 @@ class PreprintPage(OSFBasePage):
 
     class PreprintPageNavbar(Navbar):
 
-        locators = {
-            **Navbar.locators,
-            **{
-                'add_a_preprint_link': (By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(5) > a'),
-                'user_dropdown': (By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-of-type(1) > a'),
-                'sign_in_button': (By.CSS_SELECTOR, '#secondary-navigation > ul.nav > li.ember-view.dropdown.sign-in > a.btn.btn-info.btn-top-login', settings.LONG_TIMEOUT),
-            }
-        }
+        # Locators
+        add_a_preprint_link = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(5) > a')
+        user_dropdown = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-of-type(1) > a')
+        sign_in_button = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul.nav > li.ember-view.dropdown.sign-in > a.btn.btn-info.btn-top-login', settings.LONG_TIMEOUT)
 
         def verify(self):
             return self.current_service.text == 'PREPRINTS'

--- a/pages/project.py
+++ b/pages/project.py
@@ -1,16 +1,15 @@
 import settings
 import urllib.parse
 
-from pages.base import OSFBasePage
 from selenium.webdriver.common.by import By
+from pages.base import OSFBasePage, Locator
 
 
 class ProjectPage(OSFBasePage):
 
-    locators = {
-        'identity': (By.CSS_SELECTOR, '#overview > nav#projectSubnav'),
-        'project_title': (By.ID, 'nodeTitleEditable'),
-    }
+    # Locators
+    identity = Locator(By.CSS_SELECTOR, '#overview > nav#projectSubnav')
+    project_title = Locator(By.ID, 'nodeTitleEditable')
 
     def __init__(self, driver, verify=False, guid=''):
         super(self.__class__, self).__init__(driver, verify)

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -1,15 +1,14 @@
 import settings
 
-from pages.base import OSFBasePage, Navbar
 from selenium.webdriver.common.by import By
+from pages.base import OSFBasePage, Navbar, Locator
 
 
 class RegistriesPage(OSFBasePage):
     url = settings.OSF_HOME + '/registries'
 
-    locators = {
-        'identity': (By.CSS_SELECTOR, 'body.ember-application > div.ember-view > div.preprints-page > div.search-header > div.container > div.row > div > div.registries-brand', settings.LONG_TIMEOUT),
-    }
+    # Locators
+    identity = Locator(By.CSS_SELECTOR, 'body.ember-application > div.ember-view > div.preprints-page > div.search-header > div.container > div.row > div > div.registries-brand', settings.LONG_TIMEOUT)
 
     def __init__(self, driver, verify=False):
         super(RegistriesPage, self).__init__(driver, verify)
@@ -17,13 +16,9 @@ class RegistriesPage(OSFBasePage):
 
     class RegistriesPageNavbar(Navbar):
 
-        locators = {
-            **Navbar.locators,
-            **{
-                'user_dropdown': (By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-of-type(1) > a'),
-                'sign_in_button': (By.CSS_SELECTOR, '#secondary-navigation > ul.nav > li.ember-view.dropdown.sign-in > a.btn.btn-info.btn-top-login', settings.LONG_TIMEOUT),
-            }
-        }
+        # Locators
+        user_dropdown = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-of-type(1) > a')
+        sign_in_button = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul.nav > li.ember-view.dropdown.sign-in > a.btn.btn-info.btn-top-login', settings.LONG_TIMEOUT)
 
         def verify(self):
             return self.current_service.text == 'REGISTRIES'

--- a/settings/defaults.py
+++ b/settings/defaults.py
@@ -13,6 +13,6 @@ SEL_WAIT = 5
 TIMEOUT = 10
 LONG_TIMEOUT = 30
 
-OSF_HOME = 'http://localhost:5000'
-API_DOMAIN = 'http://localhost:8000'
+OSF_HOME = 'https://staging.osf.io'
+API_DOMAIN = 'https://staging-api.osf.io/v2'
 HEADLESS = False

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -289,7 +289,7 @@ class TestMeetingPageNavBar:
 
     def test_nagivation_bar_link_search_link_not_present(self):
         with pytest.raises(ValueError):
-            self.meeting_page.search_link
+            self.meeting_page.navbar.search_link
 
     def test_nagivation_bar_link_support_link(self):
         self.meeting_page.navbar.support_link.click()

--- a/utils.py
+++ b/utils.py
@@ -31,6 +31,12 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
             command_executor=command_executor,
             desired_capabilities=desired_capabilities
         )
+
+        # Maximize window to prevent visibility issues due to responsive design
+        if desired_capabilities.get('browser') == 'Safari':
+            driver.maximize_window()
+        else:
+            driver.set_window_size(1200, 720)
     elif driver_name == 'Chrome' and settings.HEADLESS:
         from selenium.webdriver.chrome.options import Options
         chrome_options = Options()
@@ -40,12 +46,6 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         driver = driver_cls(chrome_options=chrome_options)
     else:
         driver = driver_cls()
-
-    # Maximize window to prevent visibility issues due to responsive design
-    if desired_capabilities.get('browser') == 'Safari':
-        driver.maximize_window()
-    else:
-        driver.set_window_size(1200, 720)
 
     # Return driver
     return driver


### PR DESCRIPTION
## Purpose

The locator dictionaries made it so you could not tab complete to grab `WebElements`.

## Changes

This PR adds the `Locator` class and overrides `__get_attribute__` in `BaseElement`  to grab locator elements as expected when added to classes that are children of `BaseElement`.

This allows tab completion for the elements in tests. It also removes the random usage of tuples with arbitrary arguments. This makes it easier to know if you have made a malformed locator. 

## Side effects

Instead of locator dictionaries, all locators should be of the `Locator` class. The tests should not change.

I also changed default domain to staging and fixed local `launch_driver` locally.

## Ticket

None
