### PR TITLE
Feature/Change default domain to staging

### DIFF
--- a/settings/defaults.py
+++ b/settings/defaults.py
@@ -13,6 +13,6 @@ SEL_WAIT = 5
 TIMEOUT = 10
 LONG_TIMEOUT = 30
 
-OSF_HOME = 'http://localhost:5000'
-API_DOMAIN = 'http://localhost:8000'
+OSF_HOME = 'https://staging.osf.io'
+API_DOMAIN = 'https://staging-api.osf.io/v2'
 HEADLESS = False

--- a/utils.py
+++ b/utils.py
@@ -31,6 +31,12 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
             command_executor=command_executor,
             desired_capabilities=desired_capabilities
         )
+
+        # Maximize window to prevent visibility issues due to responsive design
+        if desired_capabilities.get('browser') == 'Safari':
+            driver.maximize_window()
+        else:
+            driver.set_window_size(1200, 720)
     elif driver_name == 'Chrome' and settings.HEADLESS:
         from selenium.webdriver.chrome.options import Options
         chrome_options = Options()
@@ -40,12 +46,6 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         driver = driver_cls(chrome_options=chrome_options)
     else:
         driver = driver_cls()
-
-    # Maximize window to prevent visibility issues due to responsive design
-    if desired_capabilities.get('browser') == 'Safari':
-        driver.maximize_window()
-    else:
-        driver.set_window_size(1200, 720)
 
     # Return driver
     return driver


### PR DESCRIPTION
## Purpose

`launch_driver` wasn't working locally. For QA, the default domain should be staging.

## Changes

Change default domain to staging. Fix local `launch_driver` locally.

## Side effects

None


## Ticket

None